### PR TITLE
Add platform fee to TWAMM program

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -12,7 +12,7 @@ twamm = "TWAPzC9xaeBpgDNF26z5VAcmxBowVz5uqmTx47LkWUy"
 url = "https://api.apr.dev"
 
 [provider]
-cluster = "mainnet"
+cluster = "localnet"
 wallet = "/Users/lpfinance/Users/lpfinance/.config/solana/id.json"
 
 [scripts]

--- a/app/src/crank_client.ts
+++ b/app/src/crank_client.ts
@@ -630,6 +630,8 @@ export class CrankClient {
         owner: this.provider.wallet.publicKey,
         userAccountTokenA: this.tokenAWallet,
         userAccountTokenB: this.tokenBWallet,
+        platformAccountTokenA: this.program.programId, // set as null
+        platformAccountTokenB: this.program.programId, // set as null
         tokenPair: this.tokenPair,
         transferAuthority: this.transferAuthority,
         custodyTokenA: this.tokenACustody,

--- a/app/src/env.ts
+++ b/app/src/env.ts
@@ -23,3 +23,6 @@ export const programId: string | undefined =
 export const FeeAccount = "9pvCGNF2aw43Smb4J1pdyobq6PnjwkhXkuFov8P42S5w";
 
 export const feeBps = 30;
+
+export const platformFeeAccount: string =
+  "9pvCGNF2aw43Smb4J1pdyobq6PnjwkhXkuFov8P42S5w"; // set as "" if none

--- a/autodoc.config.json
+++ b/autodoc.config.json
@@ -1,0 +1,29 @@
+{
+  "name": "twamm",
+  "repositoryUrl": "https://github.com/LP-Finance-Inc/twamm",
+  "root": ".",
+  "output": "./.autodoc",
+  "llms": [
+    "gpt-3.5-turbo"
+  ],
+  "ignore": [
+    ".*",
+    "*package-lock.json",
+    "*package.json",
+    "node_modules",
+    "*dist*",
+    "*build*",
+    "*test*",
+    "*.svg",
+    "*.md",
+    "*.mdx",
+    "*.toml",
+    "*autodoc*"
+  ],
+  "filePrompt": "Write a detailed technical explanation of what this code does. \n      Focus on the high-level purpose of the code and how it may be used in the larger project.\n      Include code examples where appropriate. Keep you response between 100 and 300 words. \n      DO NOT RETURN MORE THAN 300 WORDS.\n      Output should be in markdown format.\n      Do not just list the methods and classes in this file.",
+  "folderPrompt": "Write a technical explanation of what the code in this file does\n      and how it might fit into the larger project or work with other parts of the project.\n      Give examples of how this code might be used. Include code examples where appropriate.\n      Be concise. Include any information that may be relevant to a developer who is curious about this code.\n      Keep you response under 400 words. Output should be in markdown format.\n      Do not just list the files and folders in this folder.",
+  "chatPrompt": "",
+  "contentType": "code",
+  "targetAudience": "smart developer",
+  "linkHosted": true
+}

--- a/programs/twamm/src/instructions/cancel_order.rs
+++ b/programs/twamm/src/instructions/cancel_order.rs
@@ -251,11 +251,11 @@ pub fn cancel_order(ctx: Context<CancelOrder>, params: &CancelOrderParams) -> Re
 
     // feat/platform-fee
     if order.side == OrderSide::Sell {
-        if let Some(account) = &mut ctx.accounts.platform_account_token_b {
+        if let Some(platform_account) = &mut ctx.accounts.platform_account_token_b {
             msg!("Transfer B Fees");
             token_pair.transfer_tokens(
                 ctx.accounts.custody_token_b.to_account_info(),
-                account.to_account_info(),
+                platform_account.to_account_info(),
                 ctx.accounts.transfer_authority.clone(),
                 ctx.accounts.token_program.to_account_info(),
                 withdraw_amount_fees,
@@ -268,11 +268,11 @@ pub fn cancel_order(ctx: Context<CancelOrder>, params: &CancelOrderParams) -> Re
                 .saturating_add(withdraw_amount_fees);
         }
     } else {
-        if let Some(account) = &mut ctx.accounts.platform_account_token_a {
+        if let Some(platform_account) = &mut ctx.accounts.platform_account_token_a {
             msg!("Transfer A Fees");
             token_pair.transfer_tokens(
                 ctx.accounts.custody_token_a.to_account_info(),
-                account.to_account_info(),
+                platform_account.to_account_info(),
                 ctx.accounts.transfer_authority.clone(),
                 ctx.accounts.token_program.to_account_info(),
                 withdraw_amount_fees,

--- a/programs/twamm/src/instructions/cancel_order.rs
+++ b/programs/twamm/src/instructions/cancel_order.rs
@@ -250,33 +250,35 @@ pub fn cancel_order(ctx: Context<CancelOrder>, params: &CancelOrderParams) -> Re
     )?;
 
     // feat/platform-fee
-    // update token pair stats
-    msg!("Update token pair stats");
     if order.side == OrderSide::Sell {
-        if ctx.accounts.platform_account_token_b.is_some() {
+        if let Some(account) = &mut ctx.accounts.platform_account_token_b {
+            msg!("Transfer B Fees");
             token_pair.transfer_tokens(
                 ctx.accounts.custody_token_b.to_account_info(),
-                ctx.accounts.user_account_token_b.to_account_info(),
+                account.to_account_info(),
                 ctx.accounts.transfer_authority.clone(),
                 ctx.accounts.token_program.to_account_info(),
-                withdraw_amount_b,
+                withdraw_amount_fees,
             )?;
         } else {
+            msg!("Update token pair stats");
             token_pair.stats_b.fees_collected = token_pair
                 .stats_b
                 .fees_collected
                 .saturating_add(withdraw_amount_fees);
         }
     } else {
-        if ctx.accounts.platform_account_token_a.is_some() {
+        if let Some(account) = &mut ctx.accounts.platform_account_token_a {
+            msg!("Transfer A Fees");
             token_pair.transfer_tokens(
                 ctx.accounts.custody_token_a.to_account_info(),
-                ctx.accounts.user_account_token_a.to_account_info(),
+                account.to_account_info(),
                 ctx.accounts.transfer_authority.clone(),
                 ctx.accounts.token_program.to_account_info(),
-                withdraw_amount_a,
+                withdraw_amount_fees,
             )?;
         } else {
+            msg!("Update token pair stats");
             token_pair.stats_a.fees_collected = token_pair
                 .stats_a
                 .fees_collected

--- a/tests/1_basics.ts
+++ b/tests/1_basics.ts
@@ -520,6 +520,11 @@ describe("basics", () => {
     await twamm.cancelOrder(0, 3, 1000);
   });
 
+  it("cancelOrderWithPlatform", async () => {
+    await twamm.placeOrder(0, "sell", 3, 100);
+    await twamm.cancelOrderWithPlatform(0, 3, 100);
+  })
+
   it("setOraclePrice", async () => {
     await twamm.setOraclePrice(1000, 1000);
   });

--- a/tests/5_single_user_with_platform.ts
+++ b/tests/5_single_user_with_platform.ts
@@ -1,0 +1,225 @@
+import * as anchor from "@project-serum/anchor";
+import { TwammTester, OrderSide } from "./twamm_tester";
+import { expect, assert } from "chai";
+
+describe("single_user_with_platform", () => {
+  let twamm = new TwammTester();
+  let tifs = [0, 300, 0, 900, 0, 0, 0, 0, 0, 0];
+  let tif = 300;
+  let tokenAPrice = 30;
+  let tokenBPrice = 1;
+  let side: OrderSide = "buy";
+  let reverseSide: OrderSide = "sell";
+  let amount = 40000;
+  let settleAmountSmall = 20000;
+  let settleAmountFull = 10000000;
+
+  it("init", async () => {
+    await twamm.init();
+  });
+
+  it("scenario1", async () => {
+    await twamm.reset(tifs, [1, 10]);
+    await twamm.setOraclePrice(tokenAPrice, tokenBPrice);
+
+    // place and check order
+    const [ta_balance, tb_balance] = await twamm.getBalances(0);
+    console.log(ta_balance, tb_balance);
+    await twamm.placeOrder(0, side, tif, amount);
+
+    const [ta_balance2, tb_balance2] = await twamm.getBalances(0);
+    console.log(ta_balance2, tb_balance2)
+    expect(ta_balance2).to.equal(ta_balance);
+    expect(tb_balance2).to.equal(tb_balance - amount);
+
+    let order = await twamm.getOrder(0, tif);
+
+    let orderExpected = {
+      owner: twamm.users[0].publicKey,
+      time: new anchor.BN(0),
+      side: { buy: {} },
+      pool: await twamm.getPoolKey(tif, 0),
+      lpBalance: new anchor.BN(amount),
+      tokenDebt: new anchor.BN(0),
+      unsettledBalance: new anchor.BN(amount),
+      settlementDebt: new anchor.BN(0),
+      lastBalanceChangeTime: new anchor.BN(0),
+      bump: order.bump,
+    };
+    expect(JSON.stringify(order)).to.equal(JSON.stringify(orderExpected));
+
+    // settle
+    await twamm.setTime(135);
+    await twamm.settle(reverseSide, settleAmountSmall);
+
+    // cancel
+    await twamm.cancelOrderWithPlatform(0, tif, amount);
+    await twamm.ensureFails(twamm.getOrder(0, tif));
+
+    // check platform fees
+    let [post_ta_balance, ] = await twamm.getBalances(0);
+    let [platform_a_balance, platform_b_balance] = await twamm.getPlatformBalances()
+
+    // As fee was 10%, user a balance delta is 9 times of platform a fee 
+    // amount_token_a = 20000, fee = 20000 * 0.1 = 2000, receive_amount_token_a = 18000
+    expect(post_ta_balance - ta_balance2).to.equal(platform_a_balance * 9);
+
+    // check fees
+    let tokenPair = await twamm.program.account.tokenPair.fetch(
+      twamm.tokenPairKey
+    );
+    let fees_collected = Number(tokenPair.statsA.feesCollected);
+
+    expect(fees_collected).to.equal(0); // settle fee was set to 0
+    expect(Number(tokenPair.statsB.feesCollected)).to.equal(0);
+  });
+
+  it("scenario2", async () => {
+    await twamm.deleteTestPool(0, tif);
+    await twamm.reset(tifs, [1, 10]);
+
+    const [ta_balance, tb_balance] = await twamm.getBalances(0);
+    const [platform_a_balance, platform_b_balance] = await twamm.getPlatformBalances(0);
+    await twamm.placeOrder(0, side, tif, amount);
+    await twamm.setTime(135);
+    await twamm.settle(reverseSide, settleAmountFull);
+
+    const [ta_balance1, tb_balance1] = await twamm.getBalances(1);
+    await twamm.placeOrder(1, side, tif, amount, true);
+
+    await twamm.cancelOrderWithPlatform(0, tif, amount);
+    let tokenPair = await twamm.program.account.tokenPair.fetch(
+      twamm.tokenPairKey
+    );
+    let fees_collected = Number(tokenPair.statsA.feesCollected);
+    let source_amount_received = twamm.getTokenAAmount(amount / 2);
+    expect(Number(tokenPair.statsA.feesCollected)).to.equal(0);
+    expect(Number(tokenPair.statsB.feesCollected)).to.equal(0);
+
+    await twamm.cancelOrderWithPlatform(1, tif, amount, true);
+    const [ta_balance2, tb_balance2] = await twamm.getBalances(1);
+    expect(ta_balance2).to.equal(ta_balance1);
+    expect(tb_balance2).to.equal(tb_balance1);
+
+    const [ta_balance3, tb_balance3] = await twamm.getBalances(0);
+    expect(ta_balance3).to.equal(
+      ta_balance +
+        source_amount_received -
+        Number(tokenPair.statsA.feesCollected)
+    );
+    expect(tb_balance3).to.equal(tb_balance - amount / 2);
+
+    const [ta_balance4, tb_balance4] = await twamm.getBalances(3);
+    let sol_fees = await twamm.getExtraSolBalance(twamm.authorityKey);
+    expect(sol_fees).to.greaterThan(0);
+    await twamm.withdrawFees(fees_collected, 0, sol_fees);
+    const [ta_balance5, tb_balance5] = await twamm.getBalances(3);
+    expect(ta_balance5).to.equal(ta_balance4 + fees_collected);
+    expect(tb_balance5).to.equal(tb_balance4);
+  });
+
+  it("scenario3", async () => {
+    await twamm.deleteTestPool(0, tif);
+    await twamm.reset(tifs, [1, 10]);
+
+    const [ta_balance, tb_balance] = await twamm.getBalances(0);
+    await twamm.placeOrder(0, side, tif, amount);
+    await twamm.setTime(135);
+    await twamm.settle(reverseSide, settleAmountFull);
+
+    await twamm.cancelOrderWithPlatform(0, tif, amount);
+    let tokenPair = await twamm.program.account.tokenPair.fetch(
+      twamm.tokenPairKey
+    );
+    let fees_collected = Number(tokenPair.statsA.feesCollected);
+    let source_amount_received = twamm.getTokenAAmount(amount / 2);
+    expect(fees_collected).to.equal(Math.ceil(source_amount_received / 10));
+    expect(Number(tokenPair.statsB.feesCollected)).to.equal(0);
+
+    const [ta_balance3, tb_balance3] = await twamm.getBalances(0);
+    expect(ta_balance3).to.equal(
+      ta_balance +
+        source_amount_received -
+        Number(tokenPair.statsA.feesCollected)
+    );
+    expect(tb_balance3).to.equal(tb_balance - amount / 2);
+
+    const [ta_balance4, tb_balance4] = await twamm.getBalances(3);
+    let sol_fees = await twamm.getExtraSolBalance(twamm.authorityKey);
+    expect(sol_fees).to.greaterThan(0);
+    await twamm.withdrawFees(fees_collected, 0, sol_fees);
+    const [ta_balance5, tb_balance5] = await twamm.getBalances(3);
+    expect(ta_balance5).to.equal(ta_balance4 + fees_collected);
+    expect(tb_balance5).to.equal(tb_balance4);
+  });
+
+  it("scenario4", async () => {
+    let side: OrderSide = "sell";
+    let reverseSide: OrderSide = "buy";
+    let amount = 1333333;
+    let settleAmountSmall = 600;
+    await twamm.reset(tifs, [1, 10]);
+    await twamm.setOraclePrice(tokenAPrice, tokenBPrice);
+
+    // place and check order
+    const [ta_balance, tb_balance] = await twamm.getBalances(0);
+    await twamm.placeOrder(0, side, tif, amount);
+
+    const [ta_balance2, tb_balance2] = await twamm.getBalances(0);
+    expect(ta_balance2).to.equal(ta_balance - amount);
+    expect(tb_balance2).to.equal(tb_balance);
+
+    let order = await twamm.getOrder(0, tif);
+
+    let orderExpected = {
+      owner: twamm.users[0].publicKey,
+      time: new anchor.BN(0),
+      side: { sell: {} },
+      pool: await twamm.getPoolKey(tif, 0),
+      lpBalance: new anchor.BN(amount),
+      tokenDebt: new anchor.BN(0),
+      unsettledBalance: new anchor.BN(amount),
+      settlementDebt: new anchor.BN(0),
+      lastBalanceChangeTime: new anchor.BN(0),
+      bump: order.bump,
+    };
+    expect(JSON.stringify(order)).to.equal(JSON.stringify(orderExpected));
+
+    // settle
+    await twamm.setTime(135);
+    await twamm.settle(reverseSide, settleAmountSmall);
+
+    // cancel
+    await twamm.cancelOrderWithPlatform(0, tif, amount);
+    await twamm.ensureFails(twamm.getOrder(0, tif));
+
+    // check fees
+    let tokenPair = await twamm.program.account.tokenPair.fetch(
+      twamm.tokenPairKey
+    );
+    let fees_collected = Number(tokenPair.statsB.feesCollected);
+    expect(fees_collected).to.equal(settleAmountSmall / 10);
+    expect(Number(tokenPair.statsA.feesCollected)).to.equal(0);
+
+    // check received amount
+    const [ta_balance3, tb_balance3] = await twamm.getBalances(0);
+    expect(tb_balance3).to.equal(
+      tb_balance + settleAmountSmall - Number(tokenPair.statsB.feesCollected)
+    );
+    expect(ta_balance3).to.equal(
+      ta_balance - twamm.getTokenAAmount(settleAmountSmall)
+    );
+
+    // withdraw fees
+    const [ta_balance4, tb_balance4] = await twamm.getBalances(3);
+    let sol_fees = await twamm.getExtraSolBalance(twamm.authorityKey);
+    expect(sol_fees).to.greaterThan(0);
+    await twamm.withdrawFees(0, fees_collected, sol_fees);
+    const [ta_balance5, tb_balance5] = await twamm.getBalances(3);
+    expect(tb_balance5).to.equal(tb_balance4 + fees_collected);
+    expect(ta_balance5).to.equal(ta_balance4);
+    tokenPair = await twamm.program.account.tokenPair.fetch(twamm.tokenPairKey);
+    expect(Number(tokenPair.statsA.feesCollected)).to.equal(0);
+    expect(Number(tokenPair.statsB.feesCollected)).to.equal(0);
+  });
+});

--- a/tests/twamm_tester.ts
+++ b/tests/twamm_tester.ts
@@ -362,6 +362,13 @@ export class TwammTester {
       .catch(() => 0);
   };
 
+  getSolBalanceFromIdx = async(index: number) => {
+    return this.provider.connection
+      .getBalance(this.users[index].publicKey)
+      .then((balance) => balance)
+      .catch(() => 0);
+  };
+
   getExtraSolBalance = async (pubkey: PublicKey) => {
     let balance = await this.provider.connection
       .getBalance(pubkey)

--- a/tests/twamm_tester.ts
+++ b/tests/twamm_tester.ts
@@ -8,6 +8,7 @@ import {
   AccountMeta,
   TransactionSignature,
   SYSVAR_RENT_PUBKEY,
+  Connection,
 } from "@solana/web3.js";
 import * as spl from "@solana/spl-token";
 
@@ -50,6 +51,10 @@ export class TwammTester {
 
   tokenAWallets: PublicKey[];
   tokenBWallets: PublicKey[];
+  // platform accounts
+  platform: Keypair;
+  tokenAPlatformWallet: PublicKey;
+  tokenBPlatformWallet: PublicKey;
 
   oracleTokenAKey: PublicKey;
   oracleTokenABump: number;
@@ -114,6 +119,13 @@ export class TwammTester {
     ]);
     this.users.push(Keypair.fromSeed(seed));
 
+    // Generate platform account
+    seed = Uint8Array.from([
+      251, 222, 108, 31, 114, 229, 147, 252, 163, 52, 150, 46, 148, 35, 127, 17,
+      20, 123, 5, 45, 214, 59, 219, 109, 209, 60, 40, 244, 5, 234, 120, 162,
+    ]);
+    this.platform = Keypair.fromSeed(seed);
+
     seed = Uint8Array.from([
       34, 252, 63, 205, 83, 121, 254, 147, 133, 101, 54, 176, 184, 2, 121, 36,
       231, 156, 164, 251, 17, 236, 116, 26, 176, 175, 241, 145, 157, 42, 109,
@@ -126,6 +138,7 @@ export class TwammTester {
       209, 101, 107, 244, 132, 192, 120, 235, 46, 187, 46, 132, 38, 17, 89, 9,
       114, 196, 244, 204, 78, 120, 140, 4, 196, 157, 1, 236, 163, 252, 141, 239,
     ]);
+
     this.tokenBMintKeypair = Keypair.fromSeed(seed);
     this.tokenBMint = this.tokenBMintKeypair.publicKey;
 
@@ -176,6 +189,9 @@ export class TwammTester {
 
     this.tokenAWallets = [];
     this.tokenBWallets = [];
+    this.tokenAPlatformWallet;
+    this.tokenBPlatformWallet;
+
     for (const wallet of this.users) {
       this.tokenAWallets.push(
         await spl.getAssociatedTokenAddress(this.tokenAMint, wallet.publicKey)
@@ -185,6 +201,9 @@ export class TwammTester {
         await spl.getAssociatedTokenAddress(this.tokenBMint, wallet.publicKey)
       );
     }
+    this.tokenAPlatformWallet = await spl.getAssociatedTokenAddress(this.tokenAMint, this.platform.publicKey);
+    this.tokenBPlatformWallet = await spl.getAssociatedTokenAddress(this.tokenBMint, this.platform.publicKey);
+    
 
     [this.oracleTokenAKey, this.oracleTokenABump] =
       await PublicKey.findProgramAddress(
@@ -287,6 +306,24 @@ export class TwammTester {
       if (tx) {
         this.confirmTx(tx);
       }
+      await this.provider.connection.requestAirdrop(
+        this.platform.publicKey,
+        1e9
+      );
+
+      await spl.createAssociatedTokenAccount(
+        this.provider.connection,
+        this.admin1,
+        this.tokenAMint,
+        this.platform.publicKey
+      );
+
+      await spl.createAssociatedTokenAccount(
+        this.provider.connection,
+        this.admin1,
+        this.tokenBMint,
+        this.platform.publicKey
+      );
     }
   };
 
@@ -667,9 +704,8 @@ export class TwammTester {
     lpAmount: number,
     nextPool?: boolean
   ) => {
-    // console.log(
-    //   this.program.idl.instructions[19].accounts
-    // )
+    let platformAccountTokenA = this.tokenAPlatformWallet;
+
     await this.program.methods
       .cancelOrder({
         lpAmount: new anchor.BN(lpAmount),
@@ -679,8 +715,8 @@ export class TwammTester {
         owner: this.users[userId].publicKey,
         userAccountTokenA: this.tokenAWallets[userId],
         userAccountTokenB: this.tokenBWallets[userId],
-        platformAccountTokenA: this.program.programId, // None
-        platformAccountTokenB: this.program.programId, // None
+        platformAccountTokenA: this.tokenAPlatformWallet,//this.program.programId, //None
+        platformAccountTokenB: this.tokenBPlatformWallet,//this.program.programId, //None
         tokenPair: this.tokenPairKey,
         transferAuthority: this.authorityKey,
         custodyTokenA: this.tokenACustodyKey,
@@ -696,7 +732,40 @@ export class TwammTester {
           console.error(err);
         }
         throw err;
-      });
+      }); 
+
+      // disable when no platform fee
+      let signerABalance = await this.provider
+        .connection
+        .getTokenAccountBalance(this.tokenAWallets[userId]);
+      let signerBBalance = await this.provider
+        .connection
+        .getTokenAccountBalance(this.tokenBWallets[userId]);
+
+      let feeAccountABalance = await this.provider
+        .connection
+        .getTokenAccountBalance(this.tokenAPlatformWallet);
+      let feeAccountBBalance = await this.provider
+        .connection
+        .getTokenAccountBalance(this.tokenBPlatformWallet);
+
+      let custodyTokenABalance = await this.provider
+        .connection
+        .getTokenAccountBalance(this.tokenACustodyKey);
+      let custodyTokenBBalance = await this.provider
+        .connection
+        .getTokenAccountBalance(this.tokenBCustodyKey);
+      
+      console.log("SIGNER A BALANCE: ", signerABalance.value.amount);
+      console.log("SIGNER B BALANCE: ", signerBBalance.value.amount);
+      console.log("CUSTODY A BALANCE: ", custodyTokenABalance.value.amount);
+      console.log("CUSTODY B BALANCE: ", custodyTokenBBalance.value.amount);
+      console.log("Fee A: ", feeAccountABalance.value.amount);
+      console.log("Fee B: ", feeAccountBBalance.value.amount);
+      
+      if (parseInt(feeAccountABalance.value.amount) == 0 && parseInt(feeAccountBBalance.value.amount) == 0) {
+        console.log("FEES NOT COLLECTED!!!");
+      }
   };
 
   initPoolMetas = async (tifs: number[]) => {

--- a/tests/twamm_tester.ts
+++ b/tests/twamm_tester.ts
@@ -667,6 +667,9 @@ export class TwammTester {
     lpAmount: number,
     nextPool?: boolean
   ) => {
+    // console.log(
+    //   this.program.idl.instructions[19].accounts
+    // )
     await this.program.methods
       .cancelOrder({
         lpAmount: new anchor.BN(lpAmount),
@@ -676,6 +679,8 @@ export class TwammTester {
         owner: this.users[userId].publicKey,
         userAccountTokenA: this.tokenAWallets[userId],
         userAccountTokenB: this.tokenBWallets[userId],
+        platformAccountTokenA: this.program.programId, // None
+        platformAccountTokenB: this.program.programId, // None
         tokenPair: this.tokenPairKey,
         transferAuthority: this.authorityKey,
         custodyTokenA: this.tokenACustodyKey,

--- a/ts/3_withdraw_fees.ts
+++ b/ts/3_withdraw_fees.ts
@@ -59,11 +59,29 @@ const withdrawFees = async() => {
         mint: tokenBMint
       }
     )
+
+    let balance = await connection
+      .getBalance(authorityKey)
+      .then((balance) => balance)
+      .catch(() => 0);
+    let accountInfo = await connection.getAccountInfo(authorityKey);
+    let dataSize = accountInfo ? accountInfo.data.length : 0;
+    let minBalance =
+      await connection.getMinimumBalanceForRentExemption(
+        dataSize
+      );
+    let amountSol;
+    if (balance > minBalance) {
+      amountSol = balance - minBalance;
+    } else {
+      amountSol = 0;
+    }
+
     let tx = await program.methods
         .withdrawFees({
-            amountTokenA: new anchor.BN(0.027180869*10**9), // with decimals
+            amountTokenA: new anchor.BN(0*10**9), // with decimals
             amountTokenB: new anchor.BN(0*10**6), // with decimals
-            amountSol: new anchor.BN(0)
+            amountSol: new anchor.BN(amountSol)
         })
         .accounts({
             admin: signer.publicKey,


### PR DESCRIPTION
### Overview
- If a platform (frontend provider) adds an optional account (token a & b ATA) to `cancelOrder`, a platform can earn 100% of fees.

### Program change + test
1. Optional accounts `platform_account_token_a` and `platform_account_token_b` added to `cancel_order.rs`.
2. If platform fee defined, do not update token `token_pair.stats_a&b.fees_collected`.
3. Withdrawing extra SOL balance is intended to be at `withdrawFees`, not the platform account.
4. Test script in `5_single_user_with_platform`